### PR TITLE
Add player navigation menu

### DIFF
--- a/scepter-client/src/App.tsx
+++ b/scepter-client/src/App.tsx
@@ -1,5 +1,11 @@
 import { Routes, Route } from 'react-router-dom'
 import HomePage from './components/HomePage.tsx'
+import PlayerView from './components/PlayerView.tsx'
+import Overview from './components/player/Overview.tsx'
+import Planets from './components/player/Planets.tsx'
+import Technology from './components/player/Technology.tsx'
+import CardInventory from './components/player/CardInventory.tsx'
+import Objectives from './components/player/Objectives.tsx'
 import './styles/App.css'
 
 function App() {
@@ -12,12 +18,14 @@ function App() {
           <p>Coming Soon</p>
         </div>
       } />
-      <Route path="/join" element={
-        <div className="placeholder-page">
-          <h1>Join as Player</h1>
-          <p>Coming Soon</p>
-        </div>
-      } />
+      <Route path="/join/*" element={<PlayerView />}> 
+        <Route index element={<Overview />} />
+        <Route path="overview" element={<Overview />} />
+        <Route path="planets" element={<Planets />} />
+        <Route path="technology" element={<Technology />} />
+        <Route path="cards" element={<CardInventory />} />
+        <Route path="objectives" element={<Objectives />} />
+      </Route>
       <Route path="/settings" element={
         <div className="placeholder-page">
           <h1>Settings</h1>

--- a/scepter-client/src/components/PlayerView.tsx
+++ b/scepter-client/src/components/PlayerView.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react'
+import { Link, Outlet } from 'react-router-dom'
+import '../styles/PlayerView.css'
+
+function PlayerView() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="player-view">
+      <div className="backdrop" />
+      <button className="menu-toggle" onClick={() => setOpen(!open)}>
+        &#9776;
+      </button>
+      <nav className={`side-menu ${open ? 'open' : ''}`}>
+        <ul>
+          <li>
+            <Link className="nav-button" to="overview" onClick={() => setOpen(false)}>
+              Overview
+            </Link>
+          </li>
+          <li>
+            <Link className="nav-button" to="planets" onClick={() => setOpen(false)}>
+              Planets
+            </Link>
+          </li>
+          <li>
+            <Link className="nav-button" to="technology" onClick={() => setOpen(false)}>
+              Technology
+            </Link>
+          </li>
+          <li>
+            <Link className="nav-button" to="cards" onClick={() => setOpen(false)}>
+              Card Inventory
+            </Link>
+          </li>
+          <li>
+            <Link className="nav-button" to="objectives" onClick={() => setOpen(false)}>
+              Objectives
+            </Link>
+          </li>
+        </ul>
+      </nav>
+      <div className="page-content">
+        <Outlet />
+      </div>
+    </div>
+  )
+}
+
+export default PlayerView

--- a/scepter-client/src/components/player/CardInventory.tsx
+++ b/scepter-client/src/components/player/CardInventory.tsx
@@ -1,0 +1,12 @@
+import '../../styles/PlayerView.css'
+
+function CardInventory() {
+  return (
+    <div className="player-page">
+      <h1>Card Inventory</h1>
+      <p>Coming Soon</p>
+    </div>
+  )
+}
+
+export default CardInventory

--- a/scepter-client/src/components/player/Objectives.tsx
+++ b/scepter-client/src/components/player/Objectives.tsx
@@ -1,0 +1,12 @@
+import '../../styles/PlayerView.css'
+
+function Objectives() {
+  return (
+    <div className="player-page">
+      <h1>Objectives</h1>
+      <p>Coming Soon</p>
+    </div>
+  )
+}
+
+export default Objectives

--- a/scepter-client/src/components/player/Overview.tsx
+++ b/scepter-client/src/components/player/Overview.tsx
@@ -1,0 +1,12 @@
+import '../../styles/PlayerView.css'
+
+function Overview() {
+  return (
+    <div className="player-page">
+      <h1>Overview</h1>
+      <p>Coming Soon</p>
+    </div>
+  )
+}
+
+export default Overview

--- a/scepter-client/src/components/player/Planets.tsx
+++ b/scepter-client/src/components/player/Planets.tsx
@@ -1,0 +1,12 @@
+import '../../styles/PlayerView.css'
+
+function Planets() {
+  return (
+    <div className="player-page">
+      <h1>Planets</h1>
+      <p>Coming Soon</p>
+    </div>
+  )
+}
+
+export default Planets

--- a/scepter-client/src/components/player/Technology.tsx
+++ b/scepter-client/src/components/player/Technology.tsx
@@ -1,0 +1,12 @@
+import '../../styles/PlayerView.css'
+
+function Technology() {
+  return (
+    <div className="player-page">
+      <h1>Technology</h1>
+      <p>Coming Soon</p>
+    </div>
+  )
+}
+
+export default Technology

--- a/scepter-client/src/styles/PlayerView.css
+++ b/scepter-client/src/styles/PlayerView.css
@@ -1,0 +1,126 @@
+.player-view {
+  position: relative;
+  min-height: 100vh;
+  width: 100vw;
+}
+
+.backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image: url('../assets/backdrop.jpg');
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  z-index: -1;
+}
+
+.menu-toggle {
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+  background: transparent;
+  border: none;
+  color: #fff;
+  font-size: 2rem;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.side-menu {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 220px;
+  height: 100%;
+  padding: 5rem 1rem 1rem;
+  background: rgba(0, 0, 0, 0.8);
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  z-index: 1;
+}
+
+.side-menu.open {
+  transform: translateX(0);
+}
+
+.side-menu ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.nav-button {
+  background: linear-gradient(145deg, #2a2a2a, #1a1a1a);
+  border: 2px solid #444;
+  color: #ffffff;
+  font-size: 1.2rem;
+  font-weight: 600;
+  padding: 0.8rem 1rem;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  box-shadow:
+    0 4px 8px rgba(0, 0, 0, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  position: relative;
+  overflow: hidden;
+  display: block;
+  text-align: center;
+  text-decoration: none;
+}
+
+.nav-button::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.1), transparent);
+  transition: left 0.5s ease;
+}
+
+.nav-button:hover {
+  background: linear-gradient(145deg, #3a3a3a, #2a2a2a);
+  border-color: #666;
+  transform: translateY(-2px);
+  box-shadow:
+    0 6px 12px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.15);
+}
+
+.nav-button:hover::before {
+  left: 100%;
+}
+
+.nav-button:active {
+  transform: translateY(0);
+  box-shadow:
+    0 2px 4px rgba(0, 0, 0, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  background: linear-gradient(145deg, #1a1a1a, #0a0a0a);
+}
+
+.page-content {
+  padding-top: 4rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #fff;
+  min-height: 100vh;
+}
+
+.player-page {
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- implement new PlayerView layout with side menu
- add placeholder pages for Overview, Planets, Technology, Card Inventory and Objectives
- update routing to use PlayerView for /join
- style PlayerView with space backdrop and nav buttons

## Testing
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_b_68435d68d2d88323b258a48698795ccb